### PR TITLE
Path query alias fix

### DIFF
--- a/lib/uri/query_params/extensions/uri/generic.rb
+++ b/lib/uri/query_params/extensions/uri/generic.rb
@@ -9,8 +9,6 @@ module URI
 
     private
 
-    alias raw_path_query path_query
-
     #
     # Parses the query parameters from the query data, populating
     # query_params with the parsed parameters.
@@ -34,6 +32,8 @@ module URI
         raw_path_query
       end
     end
+
+    alias raw_path_query path_query
 
   end
 end


### PR DESCRIPTION
Alias was defined before declaring path_query function.
The following error was being returned:
`/Users/buddles/.rvm/gems/ruby-2.2.2@moinhos/gems/uri-query_params-0.7.0/lib/uri/query_params/extensions/uri/generic.rb:12:inclass:Generic': undefined method path_query' for classURI::Generic' (NameError)`